### PR TITLE
Updated PHP to 7.3.

### DIFF
--- a/goss.yaml
+++ b/goss.yaml
@@ -118,3 +118,12 @@ command:
       - /usr/local/bin/pygmy
     stderr: []
     timeout: 10000
+
+  # Assert that /app is empty so that consumer CI run could checkout the codebase.
+  assert empty app:
+    exec: ls -A /app | wc -l
+    exit-status: 0
+    stdout:
+      - 0
+    stderr: []
+    timeout: 10000

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -1,7 +1,7 @@
 FROM docker/compose:1.25.4 AS docker-compose
 FROM docker:19.03 AS docker
 
-FROM amazeeio/php:7.2-cli-drupal
+FROM amazeeio/php:7.3-cli-drupal
 
 LABEL maintainer="govcms@finance.gov.au"
 LABEL description="GovCMS base image for use in CI processes"

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -22,8 +22,8 @@ RUN apk update \
 
 # Install shellcheck.
 RUN curl -L -o "/tmp/shellcheck-v0.7.1.tar.xz" "https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz" \
-  && tar --xz -xvf "/tmp/shellcheck-v0.7.1.tar.xz" \
-  && mv "shellcheck-v0.7.1/shellcheck" /usr/bin/ \
+  && tar -C /tmp --xz -xvf "/tmp/shellcheck-v0.7.1.tar.xz" \
+  && mv "/tmp/shellcheck-v0.7.1/shellcheck" /usr/bin/ \
   && chmod +x /usr/bin/shellcheck
 
 # Install BATS.

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -20,11 +20,14 @@ RUN apk update \
   && composer clear-cache \
   && rm -rf /app
 
-# Install shellcheck and BATS tools.
-RUN apk update \
-  && apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-      bats \
-      shellcheck
+# Install shellcheck.
+RUN curl -L -o "/tmp/shellcheck-v0.7.1.tar.xz" "https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz" \
+  && tar --xz -xvf "/tmp/shellcheck-v0.7.1.tar.xz" \
+  && mv "shellcheck-v0.7.1/shellcheck" /usr/bin/ \
+  && chmod +x /usr/bin/shellcheck
+
+# Install BATS.
+RUN apk update && apk add --no-cache bats
 
 # Required for docker-compose to find zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib


### PR DESCRIPTION
- Updated base image version.
- Replaced Shellcheck installation method (no longer can be installed from `edge` due to conflicts in libs in Alpine `3.10`, which is updated in the new base image).
- Added a test to assert that `/app` is empty in order to allow consumer CI runs to checkout codebases into an empty `/app` (cannot git checkout into a dir with files in it). Need this as extracting files from archives may leave files in `/app`.

Tested in projects (these PRs will not be merged):
1. https://github.com/govCMS/govCMS8/pull/450 | [![CircleCI](https://circleci.com/gh/govCMS/govCMS8/tree/feature%2Ftemp-update-ci-image-php-7.3.svg?style=svg)](https://circleci.com/gh/govCMS/govCMS8/tree/feature%2Ftemp-update-ci-image-php-7.3)
2. https://github.com/govCMS/govCMS/pull/926 | [![CircleCI](https://circleci.com/gh/govCMS/govCMS/tree/feature%2Ftemp-update-ci-image-php-7.3.svg?style=svg)](https://circleci.com/gh/govCMS/govCMS/tree/feature%2Ftemp-update-ci-image-php-7.3) - this is expected to fail as CI in `develop` is failing.
3. https://github.com/govCMS/govcms8lagoon/pull/146 | [![CircleCI](https://circleci.com/gh/govCMS/govcms8lagoon/tree/feature%2Ftemp-update-ci-image-php-7.3.svg?style=svg)](https://circleci.com/gh/govCMS/govcms8lagoon/tree/feature%2Ftemp-update-ci-image-php-7.3)
4. https://github.com/govCMS/govcmslagoon/pull/142 | [![CircleCI](https://circleci.com/gh/govCMS/govcmslagoon/tree/feature%2Ftemp-update-ci-image-php-7.3.svg?style=svg)](https://circleci.com/gh/govCMS/govcmslagoon/tree/feature%2Ftemp-update-ci-image-php-7.3)
5. https://github.com/govCMS/govcms8-scaffold-paas/pull/55 |https://projects.govcms.gov.au/GovCMS/govcms8-scaffold-paas/pipelines/116397
6. https://github.com/govCMS/govcms7-scaffold-paas/pull/14 | https://projects.govcms.gov.au/GovCMS/govcms7-scaffold-paas/pipelines/116386