### PR TITLE
Add symfony dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     ],
     "minimum-stability": "alpha",
     "require": {
-        "govcms/scaffold-tooling": "~2"
+        "govcms/scaffold-tooling": "~2",
+        "symfony/yaml": "~5",
+        "symfony/console": "~5"
     },
     "replace": {
         "drupal/core": "*",


### PR DESCRIPTION
Because we replace Drupal the symfony dependencies are not bundled and results in a fatal.

```
PHP Fatal error:  Uncaught Error: Class 'Symfony\Component\Console\Application' not found in /govcms/vendor/govcms/scaffold-tooling/scripts/validate/govcms-yaml_lint:38
```