### PR TITLE
Upgrade to PHP7.4.

### DIFF
--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -1,7 +1,7 @@
 FROM docker/compose:1.25.4 AS docker-compose
 FROM docker:19.03 AS docker
 
-FROM amazeeio/php:7.3-cli-drupal
+FROM amazeeio/php:7.4-cli-drupal
 
 LABEL maintainer="govcms@finance.gov.au"
 LABEL description="GovCMS base image for use in CI processes"


### PR DESCRIPTION
Upcoming GovCMS8 release upgrades to PHP7.4, this ensures CI is aligned.

Especially important for D9 pre-release (https://www.drupal.org/project/drupal/issues/3152660)

CI builds `edge-9.x` - when building with 7.3 but using a 7.4 runtime we hit these issues.