### PR TITLE
GOVCMS-5031: Added phpstan-banned-code package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "minimum-stability": "alpha",
     "require": {
+        "ekino/phpstan-banned-code": "^0.4.0",
         "govcms/scaffold-tooling": "~2",
         "symfony/yaml": "~5",
         "symfony/console": "~5"

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -78,5 +78,5 @@ RUN git --version \
 
 COPY composer.json /govcms/
 ENV COMPOSER_MEMORY_LIMIT=-1
-RUN composer install -d /govcms && composer cc
+RUN composer self-update --1 && composer install -d /govcms && composer cc
 ENV PATH="/govcms/vendor/bin:${PATH}"


### PR DESCRIPTION
This will be used for BATS testing for `govcms/scaffold-tooling`.

Also updated composer to latest version so we're able to use the new github oauth tokens.