### PR TITLE
Bump bats to 1.3.0

### DIFF
--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -27,7 +27,7 @@ RUN curl -L -o "/tmp/shellcheck-v0.7.1.tar.xz" "https://github.com/koalaman/shel
   && chmod +x /usr/bin/shellcheck
 
 # Install BATS.
-RUN apk update && apk add --no-cache bats
+RUN apk add --no-cache bats=1.3.0-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 # Required for docker-compose to find zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib


### PR DESCRIPTION
The latest version of `amazeeio/php:7.4-cli-drupal` is using Alpine 3.13, which locks `bats` at `1.2.1`, triggering the following error:
```
/usr/libexec/bats-core/bats-exec-file: line 194: bats-exec-test: command not found
```
There's an issue for it [here](https://github.com/bats-core/bats-core/issues/371) that has since been fixed in 1.3.0 - available in Alpine Edge currently, which is why we're using that repository to install it.