### PR TITLE
Release 2.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci:latest
 services:
-  - gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
+  - name: gitlab-registry-production.govcms.amazee.io/govcms/govcms-ci/dind:latest
+    command: ["--tls=false"]
 
 stages:
   - build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,6 @@ stages:
 build:
   stage: build
   script:
-    - printenv
     - IMAGE_TAG=$([ $CI_COMMIT_BRANCH = 'master' ] && echo 'latest' || echo 'edge')
     - scripts/prepare
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     ],
     "minimum-stability": "alpha",
     "require": {
-        "ekino/phpstan-banned-code": "^0.4.0",
         "govcms/scaffold-tooling": "~2",
         "symfony/yaml": "~5",
         "symfony/console": "~5"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "minimum-stability": "alpha",
     "require": {
+        "ekino/phpstan-banned-code": "^0.4.0",
         "govcms/scaffold-tooling": "~2",
         "symfony/yaml": "~5",
         "symfony/console": "~5"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "minimum-stability": "alpha",
     "require": {
-        "govcms/scaffold-tooling": "~2",
+        "govcms/scaffold-tooling": "~3",
         "symfony/yaml": "~5",
         "symfony/console": "~5"
     },

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -27,7 +27,7 @@ RUN curl -L -o "/tmp/shellcheck-v0.7.1.tar.xz" "https://github.com/koalaman/shel
   && chmod +x /usr/bin/shellcheck
 
 # Install BATS.
-RUN apk add --no-cache bats=1.3.0-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache bats=1.3.0-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 
 # Required for docker-compose to find zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -78,5 +78,5 @@ RUN git --version \
 
 COPY composer.json /govcms/
 ENV COMPOSER_MEMORY_LIMIT=-1
-RUN composer install -d /govcms && composer cc
+RUN composer self-update --1 && composer install -d /govcms && composer cc
 ENV PATH="/govcms/vendor/bin:${PATH}"

--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -27,7 +27,7 @@ RUN curl -L -o "/tmp/shellcheck-v0.7.1.tar.xz" "https://github.com/koalaman/shel
   && chmod +x /usr/bin/shellcheck
 
 # Install BATS.
-RUN apk update && apk add --no-cache bats
+RUN apk add --no-cache bats=1.3.0-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 # Required for docker-compose to find zlib.
 ENV LD_LIBRARY_PATH=/lib:/usr/lib

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -5,6 +5,6 @@ echo "[---] CI_REGISTRY: ${CI_REGISTRY}"
 
 if [ "$CI_COMMIT_BRANCH" != "master" ]; then
   # Pin to the develop branch for scaffold-tooling.
-  sed -i.bak -E "s#(\"govcms\/scaffold-tooling\":[[:space:]]*\").+(\")#\1dev-9x-develop\2#g" composer.json
+  sed -i.bak -E "s#(\"govcms\/scaffold-tooling\":[[:space:]]*\").+(\")#\1dev-9.x-develop\2#g" composer.json
   echo "[---] Updated to govcms/scaffold-tooling:dev-develop"
 fi

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -5,6 +5,6 @@ echo "[---] CI_REGISTRY: ${CI_REGISTRY}"
 
 if [ "$CI_COMMIT_BRANCH" != "master" ]; then
   # Pin to the develop branch for scaffold-tooling.
-  sed -i.bak -E "s#(\"govcms\/scaffold-tooling\":[[:space:]]*\").+(\")#\1dev-develop\2#g" composer.json
+  sed -i.bak -E "s#(\"govcms\/scaffold-tooling\":[[:space:]]*\").+(\")#\1dev-9x-develop\2#g" composer.json
   echo "[---] Updated to govcms/scaffold-tooling:dev-develop"
 fi


### PR DESCRIPTION
[46ce681]: Pin to scaffold-tooling @ ~3
[a42977a]: Update edge image build to use latest dev
[b4e00c5]: GOVCMS-5031: Added phpstan-banned-code package.
[c1f1db6]: Bump bats to 1.3.0
[5311683]: Internal CI pipeline updates