### PR TITLE
Replace my older fork of `ahoy` with new release

### DIFF
--- a/govcms-ci.Dockerfile
+++ b/govcms-ci.Dockerfile
@@ -41,8 +41,8 @@ RUN wget -O /usr/local/bin/jq "https://github.com/stedolan/jq/releases/download/
 
 # Install Ahoy.
 RUN arch=$(uname -m) && arch="${arch/aarch64/arm64}" && arch="${arch/x86_64/amd64}" \
-  && wget -O /tmp/ahoy.tar.gz "https://github.com/ocean/ahoy/releases/download/2.1.0/ahoy_linux_${arch}.tar.gz" \
-  && tar -xf /tmp/ahoy.tar.gz --directory /tmp && mv /tmp/ahoy /usr/local/bin/ahoy \
+  && wget -O /tmp/ahoy "https://github.com/ahoy-cli/ahoy/releases/download/2.0.1/ahoy-bin-linux-${arch}" \
+  && mv /tmp/ahoy /usr/local/bin/ahoy \
   && chmod +x /usr/local/bin/ahoy
 
 # Install Goss (and dgoss) for server validation.


### PR DESCRIPTION
I'm a maintainer of `ahoy` now, and we have [released an update, version 2.0.1](https://github.com/ahoy-cli/ahoy/releases/tag/2.0.1) (more accurate semver than my fork was). There are no breaking changes, only some Go module updates and a shift to a newer Go version for building. Further improvements and bugfixes will follow, and will be properly versioned with semver.